### PR TITLE
Use Process#clock_gettime with CLOCK_MONOTONIC instead of Time.now

### DIFF
--- a/lib/execution_time.rb
+++ b/lib/execution_time.rb
@@ -47,14 +47,14 @@ module ExecutionTime
 
       AppMetrics.reset
 
-      start     = Time.now
+      start     = Process.clock_gettime(Process::CLOCK_MONOTONIC)
       before    = GC.stat(:total_allocated_objects)
       ActiveRecord::LogSubscriber.reset_runtime
 
       result   = yield
 
       after    = GC.stat(:total_allocated_objects)
-      duration = (Time.now - start)
+      duration = (Process.clock_gettime(Process::CLOCK_MONOTONIC) - start)
       db_after = ActiveRecord::LogSubscriber.reset_runtime
 
       info = "Completed in #{(duration * 1000).round(1)}ms | Allocations: #{after - before}"


### PR DESCRIPTION
`Time.now` isn't the best solution to calculate elapsed time - instead we must use _monotonic clock_ - `Process.clock_gettime(Process::CLOCK_MONOTONIC)`.

Just like Rails - https://github.com/rails/rails/issues/34271

More info: https://blog.dnsimple.com/2018/03/elapsed-time-with-ruby-the-right-way/