### PR TITLE
Fix: ActiveRecord::LogSubscriber.reset_runtime is deprecated

### DIFF
--- a/lib/execution_time.rb
+++ b/lib/execution_time.rb
@@ -55,7 +55,7 @@ module ExecutionTime
 
       after    = GC.stat(:total_allocated_objects)
       duration = (Process.clock_gettime(Process::CLOCK_MONOTONIC) - start)
-      db_after =  ActiveRecord::RuntimeRegistry.reset
+      db_after = ActiveRecord::RuntimeRegistry.reset
 
       info = "Completed in #{(duration * 1000).round(1)}ms | Allocations: #{after - before}"
 

--- a/lib/execution_time.rb
+++ b/lib/execution_time.rb
@@ -49,13 +49,13 @@ module ExecutionTime
 
       start     = Process.clock_gettime(Process::CLOCK_MONOTONIC)
       before    = GC.stat(:total_allocated_objects)
-      ActiveRecord::LogSubscriber.reset_runtime
+      ActiveRecord::RuntimeRegistry.reset
 
       result   = yield
 
       after    = GC.stat(:total_allocated_objects)
       duration = (Process.clock_gettime(Process::CLOCK_MONOTONIC) - start)
-      db_after = ActiveRecord::LogSubscriber.reset_runtime
+      db_after =  ActiveRecord::RuntimeRegistry.reset
 
       info = "Completed in #{(duration * 1000).round(1)}ms | Allocations: #{after - before}"
 


### PR DESCRIPTION
Issue: 

[Deprecation Warning after Rails 7.1 upgrade.](https://github.com/igorkasyanchuk/execution_time/issues/7)

Description:

(https://github.com/igorkasyanchuk/execution_time/issues/7) - `ActiveRecord::LogSubscriber.reset_runtime` is deprecated. So, have replaced with `ActiveRecord::RuntimeRegistry.reset`.